### PR TITLE
Use the canonical initialization effect approach.

### DIFF
--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -1,7 +1,4 @@
-import {Component, OnInit} from '@angular/core';
-import {AppState} from './store/reducers';
-import {Store} from '@ngrx/store';
-import {HeroActionEnum} from './store/hero.actions';
+import {Component} from '@angular/core';
 
 @Component({
   selector: 'my-root',
@@ -16,15 +13,6 @@ import {HeroActionEnum} from './store/hero.actions';
   `,
   styleUrls: ['./app.component.css']
 })
-export class AppComponent implements OnInit {
+export class AppComponent {
   title = 'Tour of Heroes';
-
-  constructor(private store: Store<AppState>) {
-  }
-
-  ngOnInit(): void {
-    // ideally, we would use the defer() feature to initialize in effects,
-    // but it seems to be broken at the moment.
-    this.store.dispatch(HeroActionEnum.LOAD_HEROES.toAction());
-  }
 }

--- a/src/app/store/hero-list.effects.ts
+++ b/src/app/store/hero-list.effects.ts
@@ -16,7 +16,7 @@ import {TypedAction} from 'ngrx-enums';
 import {HeroService} from '../hero.service';
 import {HeroActionEnum} from './hero.actions';
 import {GeneralActionEnum} from './general.actions';
-
+import { defer } from 'rxjs/observable/defer';
 
 function handleError(error: any): Observable<TypedAction<any>> {
   return of(GeneralActionEnum.SET_ERROR.toAction(error));
@@ -25,10 +25,12 @@ function handleError(error: any): Observable<TypedAction<any>> {
 @Injectable()
 export class HeroListEffects {
 
-  @Effect() loadHeroes$ = HeroActionEnum.LOAD_HEROES.of(this.actions$)
-    .switchMap(() => this.svc.getHeroes())
-    .map(heroes => HeroActionEnum.LOAD_HEROES_SUCCESS.toAction(List(heroes)))
-    .catch(handleError);
+  @Effect()
+  init$ = defer(() => {
+    return this.svc.getHeroes()
+      .map(heroes => HeroActionEnum.LOAD_HEROES_SUCCESS.toAction(List(heroes)))
+      .catch(handleError);
+  });
 
   @Effect() getHero$ = HeroActionEnum.GET_HERO.of(this.actions$)
     .withLatestFrom(this.store.select<List<Hero>>(getHeroes))

--- a/src/app/store/hero.actions.ts
+++ b/src/app/store/hero.actions.ts
@@ -15,7 +15,6 @@ export class HeroAction<T> extends ActionEnumValue<T> {
 
 export class HeroActionEnumType extends ActionEnum<HeroAction<any>> {
 
-  LOAD_HEROES = new HeroAction<void>('[Hero] Load Heroes');
   LOAD_HEROES_SUCCESS = new HeroAction<List<Hero>>('[Hero] Load Heroes Success');
   GET_HERO = new HeroAction<number>('[Hero] Get Hero');
   GET_HERO_SUCCESS = new HeroAction<Hero>('[Hero] Get Hero Success');


### PR DESCRIPTION
When I wrote toh-ngrx4, the ngrx4 approach in place for initialization wasn't working, so I added a workaround of dispatching an action from AppComponent. The fixed the bug since then, so we are able to use the preferred by using a defer() operation the effect service. 

This commit updates the repository to the preferred approach.